### PR TITLE
Randomize queries we issue

### DIFF
--- a/src/dns-test.js
+++ b/src/dns-test.js
@@ -221,6 +221,14 @@ async function sendUDPQuery(domain, nameservers, rrtype, dnssec_ok, checking_dis
 
     let key = "udp" + rrtype;
     let errorKey = rrtype;
+    if (dnssec_ok) {
+        key = key + "DO";
+        errorKey = errorKey + "DO";
+    }
+    if (checking_disabled) {
+        key = key + "CD";
+        errorKey = errorKey + "CD";
+    }
 
     for (let i = 1; i <= RESOLVCONF_ATTEMPTS; i++) {
         for (let nameserver of nameservers) {
@@ -265,6 +273,14 @@ async function sendTCPQuery(domain, nameservers, rrtype, dnssec_ok, checking_dis
 
     let key = "tcp" + rrtype;
     let errorKey = rrtype;
+    if (dnssec_ok) {
+        key = key + "DO";
+        errorKey = errorKey + "DO";
+    }
+    if (checking_disabled) {
+        key = key + "CD";
+        errorKey = errorKey + "CD";
+    }
     
     for (let nameserver of nameservers) {
         try {

--- a/src/dns-test.js
+++ b/src/dns-test.js
@@ -111,16 +111,17 @@ var dnsAttempts = {
 };
 
 /**
- * Shuffle the order of DNS queries we issue
+ * Shuffle an array
+ * Borrowed from https://stackoverflow.com/a/2450976
  */
-function shuffleQueries(queries) {
-    let currentIndex = queries.length;
+function shuffleArray(array) {
+    let currentIndex = array.length;
     let randomIndex;
 
     while (currentIndex != 0) {
         randomIndex = Math.floor(Math.random() * currentIndex);
         currentIndex--;
-        [queries[currentIndex], queries[randomIndex]] = [queries[randomIndex], queries[currentIndex]];
+        [array[currentIndex], array[randomIndex]] = [array[randomIndex], array[currentIndex]];
     }
 }
 
@@ -380,8 +381,8 @@ async function sendQueries(nameservers_ipv4) {
         queries.push(() => sendTCPQuery(...args));
     }
 
-    // Shuffle the order of the list of queries, and then send the queries
-    shuffleQueries(queries);
+    // Shuffle the order of the array of queries, and then send the queries
+    shuffleArray(queries);
     for (let sendQuery of queries) {
         await sendQuery();
     }

--- a/src/dns-test.js
+++ b/src/dns-test.js
@@ -369,7 +369,7 @@ async function readNameservers() {
  * UDP and TCP.
  */
 async function sendQueries(nameservers_ipv4) {
-    // Add the query for our A record that uses the dns.resolve() WebExtensions API
+    // Add a query for our A record that uses the WebExtensions dns.resolve API as a baseline
     let queries = [];
     queries.push(() => sendUDPWebExtQuery(APEX_DOMAIN_NAME));
 

--- a/src/dns-test.js
+++ b/src/dns-test.js
@@ -7,6 +7,7 @@ const APEX_DOMAIN_NAME = "dnssec-experiment-moz.net";
 const SMIMEA_DOMAIN_NAME = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15._smimecert.dnssec-experiment-moz.net";
 const HTTPS_DOMAIN_NAME = "httpssvc.dnssec-experiment-moz.net";
 
+const A_RRTYPE = 'A';
 const QUERIES = ['AWebExt', 'A', 'ACD', 'ADO', 'ADOCD', 'RRSIG', 'DNSKEY', 'SMIMEA', 'HTTPS', 'NEWONE', 'NEWTWO', 'NEWTHREE', 'NEWFOUR']
 const RESOLVCONF_ATTEMPTS = 2; // Number of UDP attempts per nameserver. We let TCP handle re-transmissions on its own.
 
@@ -345,28 +346,32 @@ async function sendQueries(nameservers_ipv4) {
         if (rrtype == 'AWebExt') {
             // Send query over UDP for our A record using the WebExtensions dns.resolve API as a baseline
             await sendUDPWebExtQuery(APEX_DOMAIN_NAME);
+        } else if (rrtype == 'A') {
+            // Send queries over UDP and TCP for our A record using our experimental APIs with DO=0 and CD=0
+            await sendUDPQuery(APEX_DOMAIN_NAME, nameservers_ipv4, A_RRTYPE, false, false);
+            await sendTCPQuery(APEX_DOMAIN_NAME, nameservers_ipv4, A_RRTYPE, false, false);
         } else if (rrtype == 'ACD') {
             // Send queries over UDP and TCP for our A record using our experimental APIs with DO=0 and CD=1
-            await sendUDPQuery(APEX_DOMAIN_NAME, nameservers_ipv4, rrtype, false, true);
-            await sendTCPQuery(APEX_DOMAIN_NAME, nameservers_ipv4, rrtype, false, true);
+            await sendUDPQuery(APEX_DOMAIN_NAME, nameservers_ipv4, A_RRTYPE, false, true);
+            await sendTCPQuery(APEX_DOMAIN_NAME, nameservers_ipv4, A_RRTYPE, false, true);
         } else if (rrtype == 'ADO') {
             // Send queries over UDP and TCP for our A record using our experimental APIs with DO=1 and CD=0
-            await sendUDPQuery(APEX_DOMAIN_NAME, nameservers_ipv4, rrtype, true, false);
-            await sendTCPQuery(APEX_DOMAIN_NAME, nameservers_ipv4, rrtype, true, false);
+            await sendUDPQuery(APEX_DOMAIN_NAME, nameservers_ipv4, A_RRTYPE, true, false);
+            await sendTCPQuery(APEX_DOMAIN_NAME, nameservers_ipv4, A_RRTYPE, true, false);
         } else if (rrtype == 'ADOCD') {
             // Send queries over UDP and TCP for our A record using our experimental APIs with DO=1 and CD=1
-            await sendUDPQuery(APEX_DOMAIN_NAME, nameservers_ipv4, rrtype, true, true);
-            await sendTCPQuery(APEX_DOMAIN_NAME, nameservers_ipv4, rrtype, true, true);
+            await sendUDPQuery(APEX_DOMAIN_NAME, nameservers_ipv4, A_RRTYPE, true, true);
+            await sendTCPQuery(APEX_DOMAIN_NAME, nameservers_ipv4, A_RRTYPE, true, true);
         } else if (rrtype == 'SMIMEA') {
-            // Send queries over UDP and TCP for our SMIMEA record using our experiental APIs with DO=0 and CD=0
+            // Send queries over UDP and TCP for our SMIMEA record using our experimental APIs with DO=0 and CD=0
             await sendUDPQuery(SMIMEA_DOMAIN_NAME, nameservers_ipv4, rrtype, false, false);
             await sendTCPQuery(SMIMEA_DOMAIN_NAME, nameservers_ipv4, rrtype, false, false);
         } else if (rrtype == 'HTTPS') {
-            // Send queries over UDP and TCP for our HTTPS record using our experiental APIs with DO=0 and CD=0
+            // Send queries over UDP and TCP for our HTTPS record using our experimental APIs with DO=0 and CD=0
             await sendUDPQuery(HTTPS_DOMAIN_NAME, nameservers_ipv4, rrtype, false, false);
             await sendTCPQuery(HTTPS_DOMAIN_NAME, nameservers_ipv4, rrtype, false, false);
         } else {
-            // Send queries over UDP and TCP for a record we host using our experiental APIs with DO=0 and CD=0
+            // Send queries over UDP and TCP for a record we host using our experimental APIs with DO=0 and CD=0
             await sendUDPQuery(APEX_DOMAIN_NAME, nameservers_ipv4, rrtype, false, false);
             await sendTCPQuery(APEX_DOMAIN_NAME, nameservers_ipv4, rrtype, false, false);
         }


### PR DESCRIPTION
We want to randomize the order of the RRTYPES and flags that we query with to minimize caching effects. For now, we will still issue TCP queries after each UDP query, although we may want to randomize which transport protocol is used as well.

Importantly, the results shouldn't change. The telemetry pings that each client sends in a "successful" measurement should be the same as before we shuffled.