### PR TITLE
Add mozillaAddons permission in manifest.json

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12,6 +12,7 @@
     },
 
     "permissions": [
+        "mozillaAddons",
         "telemetry",
         "dns",
         "captivePortal",


### PR DESCRIPTION
This add-on is "privileged" and we now require the `mozillaAddons` permission to be specified (this is [why the `linter` task has failed on TaskCluster](https://github.com/mozilla-extensions/dnssec-interference/runs/6631603486)). This PR adds this permission.