### PR TITLE
Bump to v3.1.0 for cloudflare domain 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dnssec-interference-study",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "DNSSEC Interference Study",
   "main": "web-ext-config.js",
   "private": true,

--- a/src/dns-test.js
+++ b/src/dns-test.js
@@ -4,7 +4,7 @@ const { Buffer } = require("buffer");
 const { v4: uuidv4 } = require("uuid");
 const IP_REGEX = require("ip-regex");
 
-const APEX_DOMAIN_NAME = "dns-study.com";
+const APEX_DOMAIN_NAME = "dnssec-experiment-moz.net";
 const SMIMEA_HASH = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15";
 const EXPECTED_FETCH_RESPONSE = "Hello, world!\n";
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "DNSSEC Interference Study",
     "description": "Mozilla addon that measures rates of DNSSEC interference by middleboxes",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "hidden": true,
 
     "applications": {


### PR DESCRIPTION
This is the second version of the add-on, which has a different domain configured (and which we also need to sign)