### PR TITLE
Add v9 experiment queries

### DIFF
--- a/src/dns-test.js
+++ b/src/dns-test.js
@@ -474,7 +474,7 @@ async function sendQueries(nameservers_ipv4, sleep) {
         { key: "udp-NEWONE-alt-prefix", transport: "udp", domain: "dns-study.com", prefix: "xyz", perClient: false, query: {rrtype: "NEWONE"}},
 
         [
-            { key: "udp-A-afirst", transport: "webext", prefix: "ccc", perClient: false, query: { rrtype: "A" }},
+            { key: "webext-A-prefix", transport: "webext", prefix: "ccc", perClient: false, query: { rrtype: "A" }},
             { key: "udp-NEWONE-afirst", transport: "udp", prefix: "ccc", perClient: false, query: {rrtype: "NEWONE"}},
         ]
     ];

--- a/test/dns-test.test.js
+++ b/test/dns-test.test.js
@@ -62,24 +62,14 @@ const FAKE_UUID = uuidv4();
 const ALL_KEY_TYPES = [
     "webext-A",
     "webext-A-U",
-    "webext-A-prefix",
-    "udp-A-N",
-    "udp-A-N-U",
-    "udp-A-N-prefix",
     "udp-NEWONE",
     "udp-NEWONE-U",
-    "udp-DS",
-    "udp-DSDO",
-    "udp-RRSIG",
-    "udp-RRSIG-U",
-    "udp-A-afirst",
-    "udp-NEWONE-afirst",
-    "udp-A-afirst-U",
-    "udp-NEWONE-afirst-U",
-    "udp-A-alast",
-    "udp-NEWONE-alast",
-    "udp-A-alast-U",
-    "udp-NEWONE-alast-U"
+    "udp-NEWONE-prefix",
+    "udp-NEWONE-alt",
+    "udp-NEWONE-alt-U",
+    "udp-NEWONE-alt-prefix",
+    "webext-A-prefix",
+    "udp-NEWONE-afirst"
 ];
 
 /**
@@ -315,12 +305,12 @@ describe("dns-test.js", () => {
                     [
                         {
                             reason: 'STUDY_ERROR_UDP_MISC',
-                            errorRRTYPE: 'udp-A-N-U',
+                            errorRRTYPE: 'udp-NEWONE-U',
                             errorAttempt: 1
                         },
                         {
                             reason: 'STUDY_ERROR_UDP_MISC',
-                            errorRRTYPE: 'udp-A-N',
+                            errorRRTYPE: 'udp-NEWONE-U',
                             errorAttempt: 1
                       }
                     ],


### PR DESCRIPTION
This patch changes the fetch request to check `dns-study.com` and configures the following queries:

* A shared and unique `webext` query to `dnssec-experiment-moz.net`
* A shared and unique NEWONE query to `dnssec-experiment-moz.net`
* A shared prefixed NEWONE query to `xyz.dnssec-experiment-moz.net`
* Shared, unique, and shared prefixed NEWONE query for `dns-study.com`
* A `webext` and `NEWONE` query to `ccc.dnssec-experiment-moz.net`, in that order.