### PR TITLE
Use the Services global variable instead of the Services.jsm's exports object to get the shared global

### DIFF
--- a/src/experiments/tcpsocket/api.js
+++ b/src/experiments/tcpsocket/api.js
@@ -33,9 +33,7 @@ var tcpsocket = class tcpsocket extends ExtensionAPI {
     constructor(...args) {
         super(...args);
         ExtensionCommon.defineLazyGetter(this, "TCPSocket", () => {
-            const { TCPSocket } = Cu.getGlobalForObject(
-              ChromeUtils.import("resource://gre/modules/Services.jsm")
-            );
+            const { TCPSocket } = Cu.getGlobalForObject(Services);
             return TCPSocket;
         });
         ChromeUtils.defineModuleGetter(this, "setTimeout", "resource://gre/modules/Timer.jsm");


### PR DESCRIPTION
`Services.jsm` is going to be removed in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 shortly.
The shared system global can be retrieved from other modules, and `XPCOMUtils.jsm` could be an alternative option.
