### PR TITLE
Update extension to use major.minor versioning scheme

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dnssec-interference-study",
-  "version": "4.2.0",
+  "version": "4.2",
   "description": "DNSSEC Interference Study",
   "main": "web-ext-config.js",
   "private": true,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "DNSSEC Interference Study",
     "description": "Mozilla addon that measures rates of DNSSEC interference by middleboxes",
-    "version": "4.2.0",
+    "version": "4.2",
     "hidden": true,
 
     "applications": {


### PR DESCRIPTION
This change is needed for https://github.com/mozilla-extensions/xpi-manifest/pull/215

In [Bug 1793925](https://bugzilla.mozilla.org/show_bug.cgi?id=1793925), Firefox Desktop started to emit warnings when an extension's version doesn't match the format specified in the [MDN docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version#version_format).

To comply with this format, we need to drop the patch version on the add on pipeline web extensions.

The pipeline will now generate versions as `major.minor.date.time`